### PR TITLE
Pin VsCoq version to 2.2.0 in `devcontainer.json` for compatibility with the language server in the container

### DIFF
--- a/.devcontainer/arm64/devcontainer.json
+++ b/.devcontainer/arm64/devcontainer.json
@@ -3,7 +3,7 @@
 	"image": "ghcr.io/logsem/iris-tutorial/docker-arm64",
 	"customizations": {
 		"vscode": {
-		  "extensions": ["maximedenes.vscoq"]
+			"extensions": ["maximedenes.vscoq@2.2.0"]
 		},
 		"settings": {
 			"terminal.integrated.profiles.linux": {

--- a/.devcontainer/x86-64/devcontainer.json
+++ b/.devcontainer/x86-64/devcontainer.json
@@ -3,7 +3,7 @@
 	"image": "ghcr.io/logsem/iris-tutorial/docker-x86-64",
 	"customizations": {
 		"vscode": {
-		  "extensions": ["maximedenes.vscoq"]
+			"extensions": ["maximedenes.vscoq@2.2.0"]
 		},
 		"settings": {
 			"terminal.integrated.profiles.linux": {


### PR DESCRIPTION
The language server version installed in `docker_image/Dockerfile` is currently 2.1.7. However, this version does not meet the requirements specified by the latest version of VsCoq[^1], and the extension does not work properly.

To address this issue, I have pinned the VsCoq extension version to 2.2.0 in `devcontainer.json`.

[^1]: https://github.com/coq/vscoq/blob/34ead82bdb2c07150acfa664117358ed03c63620/client/src/utilities/versioning.ts#L31