### PR TITLE
Docs: clarify setup directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This version is known to compile with
 
 The recommended way to install the dependencies is through [opam](https://opam.ocaml.org/doc/Install.html).
 
+Clone the repository, and from the root of the repo, execute the following:
+
 1. Install [opam](https://opam.ocaml.org/doc/Install.html) if not already installed (a version greater than 2.0 is required).
 2. Install a new switch and link it to the project.
 ```


### PR DESCRIPTION
As someone not very familiar with `opam` and the workflow, when initially following the setup instructions, I was not aware that they were supposed to be executed from within the cloned repository.

This change adds a minor clarification in the project README Setup section, to make it explicit where the commands should be executed.