### PR TITLE
Fix strategy name error: rename `replicate_length` to `length_replicate`.

### DIFF
--- a/exercises/array_lock.v
+++ b/exercises/array_lock.v
@@ -196,7 +196,7 @@ Proof.
     + iPoseProof (lookup_array _ _ _ (t `mod` cap) #true with "Ha") as "[Ht Ha]".
       {
         apply list_lookup_insert.
-        rewrite replicate_length.
+        rewrite length_replicate.
         apply Nat.mod_upper_bound.
         by apply Nat.lt_neq in Hcap.
       }
@@ -425,7 +425,7 @@ Proof.
   iPoseProof (update_array _ _ _ (o `mod` cap) #true with "Ha") as "[Ht Ha]".
   {
     apply list_lookup_insert.
-    rewrite replicate_length.
+    rewrite length_replicate.
     apply Nat.mod_upper_bound.
     by apply Nat.lt_neq in Hcap.
   }

--- a/exercises/arrays.v
+++ b/exercises/arrays.v
@@ -105,7 +105,7 @@ Proof.
   {
     iPureIntro.
     symmetry.
-    apply replicate_length.
+    apply length_replicate.
   }
   iIntros "[Ha Ha']".
   wp_pures.

--- a/theories/array_lock.v
+++ b/theories/array_lock.v
@@ -196,7 +196,7 @@ Proof.
     + iPoseProof (lookup_array _ _ _ (t `mod` cap) #true with "Ha") as "[Ht Ha]".
       {
         apply list_lookup_insert.
-        rewrite replicate_length.
+        rewrite length_replicate.
         apply Nat.mod_upper_bound.
         by apply Nat.lt_neq in Hcap.
       }
@@ -425,7 +425,7 @@ Proof.
   iPoseProof (update_array _ _ _ (o `mod` cap) #true with "Ha") as "[Ht Ha]".
   {
     apply list_lookup_insert.
-    rewrite replicate_length.
+    rewrite length_replicate.
     apply Nat.mod_upper_bound.
     by apply Nat.lt_neq in Hcap.
   }

--- a/theories/arrays.v
+++ b/theories/arrays.v
@@ -105,7 +105,7 @@ Proof.
   {
     iPureIntro.
     symmetry.
-    apply replicate_length.
+    apply length_replicate.
   }
   iIntros "[Ha Ha']".
   wp_pures.

--- a/theories/merge_sort.v
+++ b/theories/merge_sort.v
@@ -340,7 +340,7 @@ Lemma merge_sort_spec (a : loc) (l : list Z) :
   rewrite Nat2Z.id.
   wp_pures.
   wp_apply (wp_array_copy_to with "[$Hb $Ha]").
-  { by rewrite replicate_length. }
+  { by rewrite length_replicate. }
   { by rewrite fmap_length. }
   iIntros "[Hb Ha]".
   wp_pures.


### PR DESCRIPTION
While attempting to prove `copy_spec` in `arrays.v`, I encountered this issue. The incorrect strategy name caused the proof to fail, and correcting it resolved the problem.

![pic](https://github.com/user-attachments/assets/266413ce-4785-483c-8511-c79ed36aca68)

Environment details:
- coq: 8.19.2
- coq-core: 8.19.2
- coq-iris: dev.2025-03-11.1.c37e7cdd
- coq-iris-heap-lang: dev.2025-03-11.1.c37e7cdd
- coq-iris-unstable: dev.2025-03-11.1.c37e7cdd
- coq-stdlib: 8.19.2
- coq-stdpp: dev.2025-02-26.0.d2e8771d
- coqide-server: 8.19.2
- vscoq-language-server: 2.2.4